### PR TITLE
Export Any Node Instead of Only Tree Root Node

### DIFF
--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -147,13 +147,13 @@ module.exports = (function(){
   };
 
   /**
-   * Exports the tree data in format specified. It maintains herirachy by adding
+   * Exports the node data in format specified. It maintains herirachy by adding
    * additional "children" property to returned value of `criteria` callback.
    *
    * @method export
-   * @memberof Tree
+   * @memberof TreeNode
    * @instance
-   * @param {Tree~criteria} criteria - Callback function that receives data in parameter
+   * @param {TreeNode~criteria} criteria - Callback function that receives data in parameter
    * and MUST return a formatted data that has to be exported. A new property "children" is added to object returned
    * that maintains the heirarchy of nodes.
    * @return {object} - {@link TreeNode}.
@@ -175,7 +175,7 @@ module.exports = (function(){
    * });
    *
    * // Export the tree
-   * var exported = tree.export(function(data){
+   * var exported = rootNode.export(function(data){
    *  return { name: data.value.name };
    * });
    *

--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -146,6 +146,79 @@ module.exports = (function(){
     });
   };
 
+  /**
+   * Exports the tree data in format specified. It maintains herirachy by adding
+   * additional "children" property to returned value of `criteria` callback.
+   *
+   * @method export
+   * @memberof Tree
+   * @instance
+   * @param {Tree~criteria} criteria - Callback function that receives data in parameter
+   * and MUST return a formatted data that has to be exported. A new property "children" is added to object returned
+   * that maintains the heirarchy of nodes.
+   * @return {object} - {@link TreeNode}.
+   * @example
+   *
+   * var rootNode = tree.insert({
+   *   key: '#apple',
+   *   value: { name: 'Apple', color: 'Red'}
+   * });
+   *
+   * tree.insert({
+   *   key: '#greenapple',
+   *   value: { name: 'Green Apple', color: 'Green'}
+   * });
+   *
+   * tree.insertToNode(rootNode,  {
+   *  key: '#someanotherapple',
+   *  value: { name: 'Some Apple', color: 'Some Color' }
+   * });
+   *
+   * // Export the tree
+   * var exported = tree.export(function(data){
+   *  return { name: data.value.name };
+   * });
+   *
+   * // Result in `exported`
+   * {
+   * "name": "Apple",
+   * "children": [
+   *   {
+   *     "name": "Green Apple",
+   *     "children": []
+   *   },
+   *   {
+   *     "name": "Some Apple",
+   *     "children": []
+   *  }
+   * ]
+   *}
+   *
+   */
+  TreeNode.prototype.export = function(criteria){
+
+    // Check if criteria is specified
+    if(!criteria || typeof criteria !== 'function')
+      throw new Error('Export criteria not specified');
+
+    // Export every node recursively
+    var exportRecur = function(node){
+      var exported = node.matchCriteria(criteria);
+      if(!exported || typeof exported !== 'object'){
+        throw new Error('Export criteria should always return an object and it cannot be null.');
+      } else {
+        exported.children = [];
+        node._childNodes.forEach(function(_child){
+          exported.children.push(exportRecur(_child));
+        });
+
+        return exported;
+      }
+    };
+
+    return exportRecur(this);
+  };
+
   // ------------------------------------
   // Export
   // ------------------------------------

--- a/src/tree.js
+++ b/src/tree.js
@@ -343,31 +343,12 @@ module.exports = (function(){
    */
   Tree.prototype.export = function(criteria){
 
-    // Check if criteria is specified
-    if(!criteria || typeof criteria !== 'function')
-    throw new Error('Export criteria not specified');
-
     // Check if rootNode is not null
     if(!this._rootNode){
       return null;
     }
 
-    // Export every node recursively
-    var exportRecur = function(node){
-      var exported = node.matchCriteria(criteria);
-      if(!exported || typeof exported !== 'object'){
-        throw new Error('Export criteria should always return an object and it cannot be null.');
-      } else {
-        exported.children = [];
-        node._childNodes.forEach(function(_child){
-          exported.children.push(exportRecur(_child));
-        });
-
-        return exported;
-      }
-    };
-
-    return exportRecur(this._rootNode);
+    return this._rootNode.export(criteria);
   };
 
 


### PR DESCRIPTION
Put the export logic on the node itself so any node can be exported. Keep export as a function on the tree itself, essentially exporting the root node.
